### PR TITLE
Migrate console to laminas-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ functional-setup:
 	docker-compose build --parallel api wait-for-it
 	docker-compose up -d api localstack postgres
 	docker-compose run --rm wait-for-it -address postgres:5432 --timeout=30 -debug
-	docker-compose run --rm membrane php public/index.php orm:schema-tool:drop --force --full-database --no-interaction
-	docker-compose run --rm membrane php public/index.php migrations:migrate --no-interaction
-	docker-compose run --rm membrane php public/index.php data-fixture:import --append
+	docker-compose run --rm membrane vendor/bin/doctrine-module orm:schema-tool:drop --force --full-database --no-interaction
+	docker-compose run --rm membrane vendor/bin/doctrine-module migrations:migrate --no-interaction
+	docker-compose run --rm membrane vendor/bin/laminas data-fixture:import --append
 	docker-compose exec -T localstack bash -c '. /scripts/wait/wait.sh'
 
 functional-test:

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "doctrine/migrations": "^3.0",
         "doctrine/persistence": "2.2.1",
         "laminas-api-tools/api-tools-content-negotiation": "^1.4",
+        "laminas/laminas-cli": "^1.2",
         "laminas/laminas-crypt": "^3.3",
         "laminas/laminas-hydrator": "^4.1",
         "laminas/laminas-log": "^2.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d0d5d1c041453f4265a22b9af8db960",
+    "content-hash": "6ba455e5d0b1feaab6fce3172b7dd95e",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -2638,6 +2638,74 @@
                 "source": "https://github.com/laminas/laminas-cache"
             },
             "time": "2019-12-31T16:22:43+00:00"
+        },
+        {
+            "name": "laminas/laminas-cli",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cli.git",
+                "reference": "725d5dbc791dd8c60865309fb35b5030a4a07a77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/725d5dbc791dd8c60865309fb35b5030a4a07a77",
+                "reference": "725d5dbc791dd8c60865309fb35b5030a4a07a77",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.11.99.4",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/console": "^5.3.7",
+                "symfony/event-dispatcher": "^5.0",
+                "symfony/polyfill-php80": "^1.17",
+                "webmozart/assert": "^1.9"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.2.0",
+                "laminas/laminas-mvc": "^3.1.1",
+                "laminas/laminas-servicemanager": "^3.4",
+                "mikey179/vfsstream": "2.0.x-dev",
+                "phpunit/phpunit": "^9.5.9",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.10"
+            },
+            "bin": [
+                "bin/laminas"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Cli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Command-line interface for Laminas projects",
+            "keywords": [
+                "cli",
+                "command",
+                "console",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-cli/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/laminas-cli/issues",
+                "rss": "https://github.com/mezzio/laminas-cli/releases.atom",
+                "source": "https://github.com/mezzio/laminas-cli"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-20T14:36:45+00:00"
         },
         {
             "name": "laminas/laminas-code",
@@ -5539,6 +5607,56 @@
             "time": "2021-03-05T17:36:06+00:00"
         },
         {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
             "name": "psr/http-client",
             "version": "1.0.1",
             "source": {
@@ -5886,6 +6004,170 @@
             "homepage": "https://symfony.com",
             "support": {
                 "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v5.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "ce7b20d69c66a20939d8952b617506a44d102130"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ce7b20d69c66a20939d8952b617506a44d102130",
+                "reference": "ce7b20d69c66a20939d8952b617506a44d102130",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/event-dispatcher-contracts": "^2",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-04T21:20:46+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "69fee1ad2332a7cbab3aca13591953da9cdb7a11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/69fee1ad2332a7cbab3aca13591953da9cdb7a11",
+                "reference": "69fee1ad2332a7cbab3aca13591953da9cdb7a11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/event-dispatcher": "^1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.4.0"
             },
             "funding": [
                 {

--- a/module/Application/Module.php
+++ b/module/Application/Module.php
@@ -10,7 +10,6 @@ use Laminas\EventManager\EventInterface;
 use Laminas\Http\Request;
 use Laminas\Mvc\ModuleRouteListener;
 use Laminas\Mvc\MvcEvent;
-use Laminas\Console\Adapter\AdapterInterface as Console;
 use Throwable;
 use Exception;
 use Laminas\Session\Container as SessionContainer;
@@ -76,12 +75,5 @@ class Module
     public function getConfig()
     {
         return include __DIR__ . '/config/module.config.php';
-    }
-
-    public function getConsoleUsage(Console $console)
-    {
-        return [
-            'data-fixture:import [--append] [--purge-with-truncate]' => 'Import fixtures into DB',
-        ];
     }
 }

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -1,6 +1,7 @@
 <?php
 
 use Application\Config\SessionSaveHandlerConfigMapper;
+use Application\Console\ImportFixtures;
 use Application\Session\SaveHandler\EncryptedSessionSaveHandler;
 use Application\Model\Entity\UserAccount;
 use Application\Controller;
@@ -327,6 +328,11 @@ return [
                 ],
             ],
         ],
+    ],
+    'laminas-cli' => [
+        'commands' => [
+            'data-fixture:import' => ImportFixtures::class,
+        ]
     ],
     'session' => [
         'config' => [

--- a/module/Application/config/services.config.php
+++ b/module/Application/config/services.config.php
@@ -1,5 +1,7 @@
 <?php
 
+use Application\Console;
+
 return [
     'aliases' => [
         'translator' => 'MvcTranslator',
@@ -29,5 +31,6 @@ return [
         \Application\Session\SaveHandler\EncryptedSessionSaveHandler::class => \Application\Session\SaveHandler\Factory\EncryptedSessionSaveHandlerFactory::class,
         \Application\Service\DoctrineMigrationVersionService::class => \Application\Service\Factory\DoctrineMigrationVersionServiceFactory::class,
         \Application\Service\SecurityLogger::class => \Application\Service\Factory\SecurityLoggerFactory::class,
+        Console\ImportFixtures::class => Console\Factory\ImportFixturesFactory::class,
     ],
 ];

--- a/module/Application/src/Application/Console/Factory/ImportFixturesFactory.php
+++ b/module/Application/src/Application/Console/Factory/ImportFixturesFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Console\Factory;
+
+use Application\Console\ImportFixtures;
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManager;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class ImportFixturesFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|mixed[] $options
+     *
+     * @return ImportFixtures
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ): ImportFixtures {
+        $entityManager = $container->get(EntityManager::class);
+
+        $purger = new ORMPurger();
+        $loader = new Loader();
+        $executor = new ORMExecutor($entityManager, $purger);
+
+        $fixtureDirectories = $container->get('Config')['doctrine']['fixtures'];
+
+        return new ImportFixtures(
+            $purger,
+            $loader,
+            $executor,
+            $fixtureDirectories
+        );
+    }
+}

--- a/module/Application/src/Application/Console/ImportFixtures.php
+++ b/module/Application/src/Application/Console/ImportFixtures.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Application\Console;
+
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ImportFixtures extends Command
+{
+    public function __construct(
+        private ORMPurger $purger,
+        private Loader $loader,
+        private ORMExecutor $executor,
+        private array $fixtureDirectories
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('append', null, InputOption::VALUE_NONE, 'The first ID or starting date to index from')
+            ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'The first ID or starting date to index from');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var bool $append */
+        $append = $input->getOption('append');
+
+        /** @var bool $truncate */
+        $truncate = $input->getOption('purge-with-truncate');
+
+        if ($truncate) {
+            $this->purger->setPurgeMode(ORMPurger::PURGE_MODE_TRUNCATE);
+        }
+
+        foreach ($this->fixtureDirectories as $dir) {
+            $this->loader->loadFromDirectory($dir);
+        }
+
+        $fixtures = $this->loader->getFixtures();
+
+        if ($fixtures) {
+            $output->writeln(sprintf('Loading %d fixtures', count($fixtures)));
+            $this->executor->execute($fixtures, $append);
+        } else {
+            $output->writeln('<fg=yellow>No fixtures found</>');
+        }
+
+        $output->writeln('<fg=green>DONE</>');
+
+        return 0;
+    }
+}

--- a/module/Application/test/ApplicationTest/Console/ImportFixturesTest.php
+++ b/module/Application/test/ApplicationTest/Console/ImportFixturesTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace ApplicationTest\Service;
+
+use Application\Console\ImportFixtures;
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ImportFixturesTest extends TestCase
+{
+    protected ORMPurger|MockObject $mockPurger;
+    protected Loader|MockObject $mockLoader;
+    protected ORMExecutor|MockObject $mockExecutor;
+    protected InputInterface|MockObject $mockInput;
+    protected OutputInterface|MockObject $mockOutput;
+
+    public function setup(): void
+    {
+        parent::setUp();
+
+        /** @var ORMPurger|MockObject */
+        $this->mockPurger = $this->createMock(ORMPurger::class);
+
+        /** @var Loader|MockObject */
+        $this->mockLoader = $this->createMock(Loader::class);
+
+        /** @var ORMExecutor|MockObject */
+        $this->mockExecutor = $this->createMock(ORMExecutor::class);
+
+        /** @var InputInterface|MockObject */
+        $this->mockInput = $this->createMock(InputInterface::class);
+
+        /** @var OutputInterface|MockObject */
+        $this->mockOutput = $this->createMock(OutputInterface::class);
+    }
+
+    public function testImportFixtures()
+    {
+        $sut = new ImportFixtures($this->mockPurger, $this->mockLoader, $this->mockExecutor, []);
+
+        $this->mockInput->expects($this->exactly(2))
+            ->method('getOption')
+            ->withConsecutive(['append'], ['purge-with-truncate'])
+            ->willReturnOnConsecutiveCalls(false, false);
+
+        $this->mockLoader->expects($this->once())
+            ->method('getFixtures')
+            ->willReturn([]);
+
+        $this->mockOutput->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(['<fg=yellow>No fixtures found</>'], ['<fg=green>DONE</>']);
+
+        $this->assertEquals(0, $sut->run($this->mockInput, $this->mockOutput));
+    }
+
+    public function testImportFixturesWithTruncate()
+    {
+        $sut = new ImportFixtures($this->mockPurger, $this->mockLoader, $this->mockExecutor, []);
+
+        $this->mockInput->expects($this->exactly(2))
+            ->method('getOption')
+            ->withConsecutive(['append'], ['purge-with-truncate'])
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        $this->mockPurger->expects($this->once())
+            ->method('setPurgeMode')
+            ->with(ORMPurger::PURGE_MODE_TRUNCATE);
+
+        $this->mockLoader->expects($this->once())
+            ->method('getFixtures')
+            ->willReturn([]);
+
+        $this->mockOutput->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(['<fg=yellow>No fixtures found</>'], ['<fg=green>DONE</>']);
+
+        $this->assertEquals(0, $sut->run($this->mockInput, $this->mockOutput));
+    }
+
+    public function testImportFixturesWithFixtureDirectories()
+    {
+        $sut = new ImportFixtures($this->mockPurger, $this->mockLoader, $this->mockExecutor, ['/root', '/migrations']);
+
+        $this->mockInput->expects($this->exactly(2))
+            ->method('getOption')
+            ->withConsecutive(['append'], ['purge-with-truncate'])
+            ->willReturnOnConsecutiveCalls(false, false);
+
+        $this->mockLoader->expects($this->exactly(2))
+            ->method('loadFromDirectory')
+            ->withConsecutive(['/root'], ['/migrations']);
+
+        $this->mockLoader->expects($this->once())
+            ->method('getFixtures')
+            ->willReturn([]);
+
+        $this->mockOutput->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(['<fg=yellow>No fixtures found</>'], ['<fg=green>DONE</>']);
+
+        $this->assertEquals(0, $sut->run($this->mockInput, $this->mockOutput));
+    }
+
+    public function testImportFixturesWithOtherFixtures()
+    {
+        $sut = new ImportFixtures($this->mockPurger, $this->mockLoader, $this->mockExecutor, []);
+
+        $this->mockInput->expects($this->exactly(2))
+            ->method('getOption')
+            ->withConsecutive(['append'], ['purge-with-truncate'])
+            ->willReturnOnConsecutiveCalls(false, false);
+
+        $this->mockLoader->expects($this->once())
+            ->method('getFixtures')
+            ->willReturn(['fixture1', 'fixture2']);
+
+        $this->mockExecutor->expects($this->once())
+            ->method('execute')
+            ->with(['fixture1', 'fixture2'], false);
+
+        $this->mockOutput->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(['Loading 2 fixtures'], ['<fg=green>DONE</>']);
+
+        $this->assertEquals(0, $sut->run($this->mockInput, $this->mockOutput));
+    }
+
+    public function testImportFixturesWithOtherFixturesAppended()
+    {
+        $sut = new ImportFixtures($this->mockPurger, $this->mockLoader, $this->mockExecutor, []);
+
+        $this->mockInput->expects($this->exactly(2))
+            ->method('getOption')
+            ->withConsecutive(['append'], ['purge-with-truncate'])
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $this->mockLoader->expects($this->once())
+            ->method('getFixtures')
+            ->willReturn(['fixture1', 'fixture2']);
+
+        $this->mockExecutor->expects($this->once())
+            ->method('execute')
+            ->with(['fixture1', 'fixture2'], true);
+
+        $this->mockOutput->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(['Loading 2 fixtures'], ['<fg=green>DONE</>']);
+
+        $this->assertEquals(0, $sut->run($this->mockInput, $this->mockOutput));
+    }
+}


### PR DESCRIPTION
Remove `laminas/laminas-mvc-console` and use `laminas/laminas-cli` instead.

This also means that doctrine commands need to be called from their own bin, since they can't hook into the MVC controller any more.

#major