### PR TITLE
Remove laminas-cache configuration #minor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,13 @@ FROM composer:2.2.4 as composer
 COPY composer.json composer.json
 COPY composer.lock composer.lock
 
-RUN mkdir -p /usr/src/php/ext/apcu \
-  && curl -fsSL https://pecl.php.net/get/apcu | tar xvz -C "/usr/src/php/ext/apcu" --strip 1 \
-  && docker-php-ext-install apcu
-
 RUN composer install --no-interaction \
   && composer dumpautoload -o
 
 FROM php:8.1.1-fpm-alpine as main
 
 RUN apk --no-cache add postgresql-dev fcgi icu-dev ncurses autoconf $PHPIZE_DEPS \
-  && mkdir -p /usr/src/php/ext/apcu && curl -fsSL https://pecl.php.net/get/apcu | tar xvz -C "/usr/src/php/ext/apcu" --strip 1 \
-  && docker-php-ext-install apcu pdo pdo_pgsql opcache intl \
+  && docker-php-ext-install pdo pdo_pgsql opcache intl \
   && docker-php-ext-enable sodium \
   && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "doctrine/migrations": "^3.3.2",
         "doctrine/persistence": "^2.2.2",
         "laminas-api-tools/api-tools-content-negotiation": "^1.4",
-        "laminas/laminas-cache-storage-adapter-apcu": "^2.0",
         "laminas/laminas-cli": "^1.2",
         "laminas/laminas-crypt": "^3.3",
         "laminas/laminas-hydrator": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab2b6da8a6023b090ecce7415cd6c58c",
+    "content-hash": "e96540d2b5ea9b63aaa70d26ba541415",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -986,16 +986,16 @@
         },
         {
             "name": "doctrine/doctrine-module",
-            "version": "4.3.0",
+            "version": "4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineModule.git",
-                "reference": "33c3f0ce9de47a2e44bdbf8f0eb10bbe0acbec60"
+                "reference": "b1db93d7d212d791571eba282f7b24c59ef4966a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineModule/zipball/33c3f0ce9de47a2e44bdbf8f0eb10bbe0acbec60",
-                "reference": "33c3f0ce9de47a2e44bdbf8f0eb10bbe0acbec60",
+                "url": "https://api.github.com/repos/doctrine/DoctrineModule/zipball/b1db93d7d212d791571eba282f7b24c59ef4966a",
+                "reference": "b1db93d7d212d791571eba282f7b24c59ef4966a",
                 "shasum": ""
             },
             "require": {
@@ -1018,7 +1018,10 @@
                 "laminas/laminas-stdlib": "^3.6.0",
                 "laminas/laminas-validator": "^2.15.0",
                 "php": "^7.3 || ~8.0.0 || ~8.1.0",
-                "symfony/console": "^5.3.7"
+                "symfony/console": "^5.3.7 || ^6.0.0"
+            },
+            "provide": {
+                "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9.0.0",
@@ -1100,7 +1103,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineModule/issues",
-                "source": "https://github.com/doctrine/DoctrineModule/tree/4.3.0"
+                "source": "https://github.com/doctrine/DoctrineModule/tree/4.4.0"
             },
             "funding": [
                 {
@@ -1116,7 +1119,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-22T09:59:03+00:00"
+            "time": "2021-12-01T10:15:04+00:00"
         },
         {
             "name": "doctrine/doctrine-orm-module",
@@ -2595,71 +2598,6 @@
                 }
             ],
             "time": "2021-11-18T16:54:49+00:00"
-        },
-        {
-            "name": "laminas/laminas-cache-storage-adapter-apcu",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-cache-storage-adapter-apcu.git",
-                "reference": "ff74fdd80222df7f486eaf830b7d58e4983dd926"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-apcu/zipball/ff74fdd80222df7f486eaf830b7d58e4983dd926",
-                "reference": "ff74fdd80222df7f486eaf830b7d58e4983dd926",
-                "shasum": ""
-            },
-            "require": {
-                "ext-apcu": "^5.1.10",
-                "laminas/laminas-cache": "^3.0",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "provide": {
-                "laminas/laminas-cache-storage-implementation": "1.0"
-            },
-            "require-dev": {
-                "laminas/laminas-cache": "3.0.x-dev || ^3.0",
-                "laminas/laminas-cache-storage-adapter-test": "2.0.x-dev || ^2.0",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.9"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "config-provider": "Laminas\\Cache\\Storage\\Adapter\\Apcu\\ConfigProvider",
-                    "module": "Laminas\\Cache\\Storage\\Adapter\\Apcu"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Cache\\Storage\\Adapter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Laminas cache adapter for apcu",
-            "keywords": [
-                "cache",
-                "laminas"
-            ],
-            "support": {
-                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-apcu/",
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-apcu/issues",
-                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-apcu/releases.atom",
-                "source": "https://github.com/laminas/laminas-cache-storage-adapter-apcu"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-11-08T06:06:13+00:00"
         },
         {
             "name": "laminas/laminas-cli",


### PR DESCRIPTION
We installed `laminas/laminas-cache-storage-adapter-apcu` because it was a dependency of `doctrine/doctrine-module`. But if we bump the doctrine module, the dependency has been removed.

This is because doctrine-module ships with [Doctrine's own cache implementation](https://www.doctrine-project.org/projects/doctrine-cache/en/1.12/index.html) and the laminas-cache-* dependency was only for [sharing caches between Doctrine and Laminas](https://www.doctrine-project.org/projects/doctrine-module/en/5.0/caching.html#caching). We have no interest in doing that, so can drop the package completely.

We can also remove the apcu extension now that we're not using it