### PR TITLE
Fix dependabot pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Dependabot PR Check"]
+    types:
+      - completed
 
 defaults:
  run:

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,0 +1,10 @@
+name: Dependabot PR Check
+on:
+  pull_request
+
+jobs:
+  check-dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - run: echo "PR created by Dependabot"


### PR DESCRIPTION
External PR builds don't have access to a write token (understandably), so Dependabot PRs cannot push their test results onto the PR comments.

To fix this, there is now a special "dependabot PR" build that only triggers for the dependabot user. When that is successfully completed, the main build job is started. Because it's now run from GitHub, not from an external user, it has the necessary permissions.

This solution was taken from [a comment on the Dependabot core repo](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425).

#patch