### PR TITLE
Adopt migration version service from external repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,6 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "git@github.com:ministryofjustice/doctrine-migration-version-checker.git"
-        },
-        {
-            "type": "vcs",
             "url": "git@github.com:ministryofjustice/jwt-laminas-auth.git"
         }
     ],
@@ -39,7 +35,6 @@
         "laminas/laminas-mvc": "^3.1",
         "laminas/laminas-mvc-i18n": "^1.1",
         "laminas/laminas-session": "^2.9",
-        "ministryofjustice/doctrine-migration-version-checker": "^4.0",
         "ministryofjustice/jwt-laminas-auth": "^4.0",
         "php-http/guzzle6-adapter": "^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3f04b60b4631df9aff80aaefb4636e9",
+    "content-hash": "0d6d38cafa1e67864eac4b5456fc0ac5",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -4725,55 +4725,6 @@
                 }
             ],
             "time": "2021-09-28T19:34:56+00:00"
-        },
-        {
-            "name": "ministryofjustice/doctrine-migration-version-checker",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ministryofjustice/doctrine-migration-version-checker.git",
-                "reference": "4e403e5433102f0b810e9ea65a94d3fb76fd2568"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ministryofjustice/doctrine-migration-version-checker/zipball/4e403e5433102f0b810e9ea65a94d3fb76fd2568",
-                "reference": "4e403e5433102f0b810e9ea65a94d3fb76fd2568",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/migrations": "^3.0",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0.0",
-                "satooshi/php-coveralls": "^2.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Ministryofjustice\\DoctrineMigrationVersionChecker\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Ministryofjustice\\DoctrineMigrationVersionCheckerTest\\": "test/"
-                }
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ali Bahman",
-                    "email": "abn@webit4.me"
-                }
-            ],
-            "description": "A small library to interact with doctrine's configuration object to retrieve information about migration version",
-            "support": {
-                "source": "https://github.com/ministryofjustice/doctrine-migration-version-checker/tree/4.0.0",
-                "issues": "https://github.com/ministryofjustice/doctrine-migration-version-checker/issues"
-            },
-            "time": "2020-12-29T13:43:08+00:00"
         },
         {
             "name": "ministryofjustice/jwt-laminas-auth",

--- a/module/Application/src/Application/Controller/HealthCheckController.php
+++ b/module/Application/src/Application/Controller/HealthCheckController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Controller;
 
 use Application\Proxy\ApplicationProxy;
+use Application\Service\MigrationVersionService;
 use Application\Service\ServiceStatusService;
 use Doctrine\DBAL\Connection;
 use Exception;
@@ -13,7 +14,6 @@ use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\JsonModel;
-use Ministryofjustice\DoctrineMigrationVersionChecker\Version;
 
 /**
  * @method Response getResponse()
@@ -77,7 +77,7 @@ class HealthCheckController extends AbstractActionController
 
     private function getCurrentMigrationVersion(): string
     {
-        $migrationVersion = new Version(
+        $migrationVersion = new MigrationVersionService(
             $this->connection,
             $this->config['doctrine']['migrations_configuration']['orm_default']
         );

--- a/module/Application/src/Application/Service/MigrationVersionService.php
+++ b/module/Application/src/Application/Service/MigrationVersionService.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
+use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use RuntimeException;
+
+class MigrationVersionService
+{
+    /**
+     * @see default keys under migrations_configuration, orm_default at
+     *   https://github.com/doctrine/DoctrineORMModule/blob/3.1.x/config/module.config.php#L158
+     */
+    public const TABLE_CONFIG_SECTION_KEY = 'table_storage';
+    public const MIGRATION_TABLE_KEY = 'table_name';
+    public const MIGRATION_PATHS_SECTION_KEY = 'migrations_paths';
+
+    public const ERR_MSG_MISSING_KEY = 'Expected key "%s" is missing in the doctrine\'s migration configuration!';
+
+    private ?DependencyFactory $dependencyFactory = null;
+
+    /**
+     * @param array<mixed> $doctrineMigrationConfig
+     *   in a usual setup comes from 'doctrine' => [ 'migrations_configuration' => ['orm_default' => []]
+     */
+    public function __construct(private Connection $conn, private array $doctrineMigrationConfig)
+    {
+    }
+
+    public function getCurrentVersion(): string
+    {
+        return strval($this->getDependencyFactory()->getVersionAliasResolver()->resolveVersionAlias('current'));
+    }
+
+    private function getDependencyFactory(): DependencyFactory
+    {
+        if (is_null($this->dependencyFactory)) {
+            $this->initMigrationConfiguration();
+        }
+
+        return $this->dependencyFactory;
+    }
+
+    private function initMigrationConfiguration(): void
+    {
+        $migrationTable = $this->getMigrationTable();
+        $migrationPaths = $this->getMigrationPaths();
+
+        $storageConfiguration = new TableMetadataStorageConfiguration();
+        $storageConfiguration->setTableName($migrationTable);
+
+        $configuration = new Configuration();
+        $configuration->setMetadataStorageConfiguration($storageConfiguration);
+
+        foreach ($migrationPaths as $namespace => $path) {
+            $configuration->addMigrationsDirectory($namespace, $path);
+        }
+
+        $this->dependencyFactory = DependencyFactory::fromConnection(new ExistingConfiguration($configuration), new ExistingConnection($this->conn));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getMigrationPaths(): array
+    {
+        $paths = $this->doctrineMigrationConfig[self::MIGRATION_PATHS_SECTION_KEY];
+        if (!is_array($paths)) {
+            throw new RuntimeException(sprintf('Expected %s to be an array, but it is not', self::MIGRATION_PATHS_SECTION_KEY));
+        }
+
+        return $paths;
+    }
+
+    private function getMigrationTable(): string
+    {
+        $table = $this->doctrineMigrationConfig[self::TABLE_CONFIG_SECTION_KEY][self::MIGRATION_TABLE_KEY];
+        if (!is_string($table)) {
+            throw new RuntimeException(sprintf('Expected %s to be a string, but it is not', self::MIGRATION_PATHS_SECTION_KEY));
+        }
+
+        return $table;
+    }
+}

--- a/module/Application/test/ApplicationTest/Service/MigrationVersionServiceTest.php
+++ b/module/Application/test/ApplicationTest/Service/MigrationVersionServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service;
+
+use Application\Service\MigrationVersionService as Version;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class TestableSchemaManager extends AbstractSchemaManager
+{
+    public function listTableNames()
+    {
+        return [];
+    }
+
+    protected function _getPortableTableColumnDefinition($tableColumn)
+    {
+        throw new RuntimeException('Not implemented');
+    }
+}
+
+class MigrationVersionServiceTest extends TestCase
+{
+    private array $mockConfig = [
+        'table_storage' => [
+            'table_name' => 'tableName',
+        ],
+        'migrations_paths' => [
+            'OPGCoreDoctrineMigrations\Fixture\DBMigrations' => '../../../../../MembraneDoctrineMigrations',
+        ],
+    ];
+
+    /**
+     * @var Connection
+     */
+    private $mockConnection;
+
+    public function setUp(): void
+    {
+        $this->mockConnection = $this->createMock(Connection::class);
+    }
+
+    public function test_getCurrentVersion_returns_latest_version(): void
+    {
+        chdir(__DIR__);
+
+        $this->mockConnection->expects(self::atLeastOnce())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SqlitePlatform());
+
+        $this->mockConnection->expects(self::atLeastOnce())
+            ->method('getSchemaManager')
+            ->willReturn(new TestableSchemaManager($this->mockConnection, new PostgreSQLPlatform()));
+
+        $service = new Version($this->mockConnection, $this->mockConfig);
+        $result = $service->getCurrentVersion();
+
+        self::assertEquals('0', $result);
+    }
+
+    /**
+     * @param array $config
+     * @param Exception|null $expectedException
+     *
+     * @dataProvider incorrectConfigDataProvider
+     */
+    public function test_getCurrentVersion_throws_exceptions_when_missing_config(array $config, string $expectedWarningMessage = null)
+    {
+        if (!is_null($expectedWarningMessage)) {
+            $this->expectWarning();
+            $this->expectWarningMessage($expectedWarningMessage);
+        }
+
+        $service = new Version($this->mockConnection, $config);
+        $service->getCurrentVersion();
+
+        self::assertInstanceOf(Version::class, $service);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function incorrectConfigDataProvider(): array
+    {
+        return [
+            [
+                'incorrectConfig' => [
+                    'migrations_paths' => [
+                        'OPGCoreDoctrineMigrations\Fixture\DBMigrations' => './Fixture/DBMigrations',
+                    ],
+                ],
+                'expectedWarningMessage' => 'Undefined array key "table_storage"',
+            ],
+            [
+                'incorrectConfig' => [
+                    'table_storage' => [
+                    ],
+                    'migrations_paths' => [
+                        'OPGCoreDoctrineMigrations\Fixture\DBMigrations' => './Fixture/DBMigrations',
+                    ],
+                ],
+                'expectedWarningMessage' => 'Undefined array key "table_name"',
+            ],
+            [
+                'incorrectConfig' => [
+                    'table_storage' => [
+                        'table_name' => 'tableName',
+                    ],
+                ],
+                'expectedWarningMessage' => 'Undefined array key "migrations_paths"',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Rather than maintaining a separate repo for one small shared file, just include it directly in the application.

The only other place it's used is Membrane, which we're getting rid of soon, and the external repo introduces unnecessary complexity and risk.

#patch