### PR TITLE
Run Trivy against full URL image tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,21 +34,6 @@ jobs:
         run: |
           make build
 
-      - name: Trivy Image Vulnerability Scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: membrane-app:latest
-          severity: 'HIGH,CRITICAL'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-
       - name: Install Inspec for Image Tests
         uses: actionshub/chef-install@main
         if: always()
@@ -114,7 +99,7 @@ jobs:
 
       - name: Bump version
         id: bump_version
-        uses: anothrNick/github-tag-action@1.36.0
+        uses: anothrNick/github-tag-action@1.39.0
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,6 +108,31 @@ jobs:
           PRERELEASE_SUFFIX: ${{ env.BRANCH_NAME }}
           RELEASE_BRANCHES: main
           WITH_V: true
+
+      - name: Tag Container
+        env:
+          ECR_REGISTRY: 311462405659
+          MEMBRANE_ECR_REPOSITORY: sirius/membrane-app
+        run: |
+          docker tag membrane-app:latest $ECR_REGISTRY/$MEMBRANE_ECR_REPOSITORY:${{ steps.bump_version.outputs.tag }}
+
+      - name: Trivy Image Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        env:
+          ECR_REGISTRY: 311462405659
+          MEMBRANE_ECR_REPOSITORY: sirius/membrane-app
+        with:
+          image-ref: ${{ env.ECR_REGISTRY }}/${{ env.MEMBRANE_ECR_REPOSITORY }}:${{ steps.bump_version.outputs.tag }}
+          severity: 'HIGH,CRITICAL'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
This generates a Sarif file that can be accepted by GitHub.

Moved Trivy later in the build process so it happens after the tag has been generated.

#patch